### PR TITLE
fix return value of handshakeTransport.writePacket()

### DIFF
--- a/ssh/handshake.go
+++ b/ssh/handshake.go
@@ -515,6 +515,7 @@ func (t *handshakeTransport) writePacket(p []byte) error {
 
 	if err := t.pushPacket(p); err != nil {
 		t.writeError = err
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
when t.pushPacket(p) returns an error, writePacket() should return the error other than nil.